### PR TITLE
Change order of our mainnet dns seeds

### DIFF
--- a/BRChainParams.h
+++ b/BRChainParams.h
@@ -47,8 +47,8 @@ typedef struct {
 } BRChainParams;
 
 static const char *BRMainNetDNSSeeds[] = {
-    "seed.bitcoin.sipa.be.", "dnsseed.bluematt.me.", "dnsseed.bitcoin.dashjr.org.", "seed.bitcoinstats.com.",
-    "seed.bitcoin.jonasschnelli.ch.", "seed.btc.petertodd.org.", NULL
+    "dnsseed.bluematt.me.", "seed.btc.petertodd.org.", "seed.bitcoin.jonasschnelli.ch.", "seed.bitcoinstats.com.",
+    "dnsseed.bitcoin.dashjr.org.", "seed.bitcoin.sipa.be.", NULL
 };
 
 static const char *BRTestNetDNSSeeds[] = {


### PR DESCRIPTION
Based on our tests, we decided to change the order of our DNS seeds, to pick the DNS seed servers that have most support to `NODE_SERVICE_WITNESS` and have a better uptime.

Here's the result of the tests:

https://pastebin.com/R8m1mrmL