### PR TITLE
Fix problem with verifying BIP38 passphrases

### DIFF
--- a/BRBIP38Key.c
+++ b/BRBIP38Key.c
@@ -172,7 +172,7 @@ int BRKeySetBIP38Key(BRKey *key, const char *bip38Key, const char *passphrase) {
 
     BRKeySetSecret(key, &secret, flag & BIP38_COMPRESSED_FLAG);
     var_clean(&secret);
-    BRKeyAddress(key, address.s, sizeof(address));
+    BRKeyLegacyAddr(key, address.s, sizeof(address));
     BRSHA256_2(&hash, address.s, strlen(address.s));
     if (! address.s[0] || memcmp(&hash, addresshash, sizeof(uint32_t)) != 0) r = 0;
     return r;


### PR DESCRIPTION
Read this to understand https://github.com/bitcoin/bips/blob/master/bip-0038.mediawiki#specification

```
Base58Check: a method for encoding arrays of bytes using 58 alphanumeric characters commonly used in the Bitcoin ecosystem.
```